### PR TITLE
refactor(auth): simplify mock querier usage in tests

### DIFF
--- a/internal/features/auth/controller_test.go
+++ b/internal/features/auth/controller_test.go
@@ -88,11 +88,9 @@ func TestController_LoginGithub(t *testing.T) {
 		jwtSecret := "controller-jwt-secret"
 		userID := uuid.New()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
-					return mockUserWithAccount, nil
-				},
+		db := &test.MockQuerier{
+			GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
+				return mockUserWithAccount, nil
 			},
 		}
 
@@ -243,17 +241,15 @@ func TestController_LoginGithubCallback(t *testing.T) {
 
 		mockTx := newMockTxSuccess()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
-				CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
-					return sqlc.Account{}, nil
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
+			},
+			CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
+				return sqlc.Account{}, nil
 			},
 		}
 

--- a/internal/features/auth/export_test.go
+++ b/internal/features/auth/export_test.go
@@ -1,19 +1,13 @@
 package auth
 
 import (
-	"github.com/ccrsxx/api/internal/test"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jackc/pgx/v5"
 )
 
-// TestMockQuerier embeds test.MockQuerier and adds WithTx
-// to satisfy auth's unexported querier interface.
-type TestMockQuerier struct {
-	test.MockQuerier
-}
-
-func (m *TestMockQuerier) WithTx(_ pgx.Tx) querier {
-	return m
+// NewTxQuerier exposes the internal tx-scoped querier factory for testing.
+func (s *Service) NewTxQuerier(tx pgx.Tx) querier {
+	return s.newTx(tx)
 }
 
 // SetSignToken overrides the package-level signToken function for testing.

--- a/internal/features/auth/middleware_test.go
+++ b/internal/features/auth/middleware_test.go
@@ -131,14 +131,12 @@ func TestMiddleware_IsAuthorizedFromOauth(t *testing.T) {
 		jwtSecret := "middleware-jwt-secret"
 		userID := uuid.New()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
-					return sqlc.GetUserWithAccountByIDRow{
-						Name: "Test User",
-						Role: "admin",
-					}, nil
-				},
+		db := &test.MockQuerier{
+			GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
+				return sqlc.GetUserWithAccountByIDRow{
+					Name: "Test User",
+					Role: "admin",
+				}, nil
 			},
 		}
 

--- a/internal/features/auth/service.go
+++ b/internal/features/auth/service.go
@@ -28,15 +28,6 @@ type querier interface {
 	CreateUser(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error)
 	UpdateUser(ctx context.Context, arg sqlc.UpdateUserParams) (sqlc.User, error)
 	CreateAccount(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error)
-	WithTx(tx pgx.Tx) querier
-}
-
-type AuthDatabaseWrapper struct {
-	*sqlc.Queries
-}
-
-func (w *AuthDatabaseWrapper) WithTx(tx pgx.Tx) querier {
-	return &AuthDatabaseWrapper{w.Queries.WithTx(tx)}
 }
 
 type githubClient interface {
@@ -46,6 +37,7 @@ type githubClient interface {
 type Service struct {
 	db                querier
 	pool              beginner
+	newTx             func(pgx.Tx) querier
 	secretKey         string
 	jwtSecret         string
 	githubClient      githubClient
@@ -71,9 +63,23 @@ const (
 )
 
 func NewService(cfg ServiceConfig) *Service {
+	// A real sqlc querier must bind each query to the transaction so writes
+	// stay atomic. Mocks don't touch a real connection, so they are reused
+	// as-is (they ignore the tx).
+	newTx := func(pgx.Tx) querier {
+		return cfg.Database
+	}
+
+	if db, ok := cfg.Database.(*sqlc.Queries); ok {
+		newTx = func(tx pgx.Tx) querier {
+			return db.WithTx(tx)
+		}
+	}
+
 	return &Service{
 		db:                cfg.Database,
 		pool:              cfg.Pool,
+		newTx:             newTx,
 		secretKey:         cfg.SecretKey,
 		jwtSecret:         cfg.JwtSecret,
 		githubClient:      cfg.GithubClient,

--- a/internal/features/auth/service_github.go
+++ b/internal/features/auth/service_github.go
@@ -110,7 +110,7 @@ func (s *Service) createNewGithubUser(ctx context.Context, githubUser github.Use
 		}
 	}()
 
-	qtx := s.db.WithTx(tx)
+	qtx := s.newTx(tx)
 
 	user, err := qtx.CreateUser(ctx, sqlc.CreateUserParams{
 		Name:  githubName,

--- a/internal/features/auth/service_github_test.go
+++ b/internal/features/auth/service_github_test.go
@@ -64,17 +64,15 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 	t.Run("Success (New User)", func(t *testing.T) {
 		mockTx := newMockTxSuccess()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
-				CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
-					return sqlc.Account{}, nil
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
+			},
+			CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
+				return sqlc.Account{}, nil
 			},
 		}
 
@@ -114,17 +112,15 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 			Name:      &newName,
 		}
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{UserID: mockUserID}, nil
-				},
-				GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				UpdateUserFn: func(ctx context.Context, arg sqlc.UpdateUserParams) (sqlc.User, error) {
-					return sqlc.User{ID: mockUserID, Name: newName}, nil
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{UserID: mockUserID}, nil
+			},
+			GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			UpdateUserFn: func(ctx context.Context, arg sqlc.UpdateUserParams) (sqlc.User, error) {
+				return sqlc.User{ID: mockUserID, Name: newName}, nil
 			},
 		}
 
@@ -170,11 +166,9 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 	})
 
 	t.Run("GetAccountByProvider DB Error", func(t *testing.T) {
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, errors.New("db error")
 			},
 		}
 
@@ -199,14 +193,12 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 	})
 
 	t.Run("GetUserByID Error", func(t *testing.T) {
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{UserID: mockUserID}, nil
-				},
-				GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
-					return sqlc.User{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{UserID: mockUserID}, nil
+			},
+			GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
+				return sqlc.User{}, errors.New("db error")
 			},
 		}
 
@@ -239,17 +231,15 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 			Name:      &newName,
 		}
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{UserID: mockUserID}, nil
-				},
-				GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				UpdateUserFn: func(ctx context.Context, arg sqlc.UpdateUserParams) (sqlc.User, error) {
-					return sqlc.User{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{UserID: mockUserID}, nil
+			},
+			GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			UpdateUserFn: func(ctx context.Context, arg sqlc.UpdateUserParams) (sqlc.User, error) {
+				return sqlc.User{}, errors.New("db error")
 			},
 		}
 
@@ -274,11 +264,9 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 	})
 
 	t.Run("Begin Error", func(t *testing.T) {
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
 			},
 		}
 
@@ -310,17 +298,15 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 	t.Run("CreateAccount Error", func(t *testing.T) {
 		mockTx := newMockTxSuccess()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
-				CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
-					return sqlc.Account{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
+			},
+			CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
+				return sqlc.Account{}, errors.New("db error")
 			},
 		}
 
@@ -355,17 +341,15 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 			RollbackFn: func(ctx context.Context) error { return pgx.ErrTxClosed },
 		}
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
-				CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
-				CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
-					return sqlc.Account{}, nil
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
+			},
+			CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
+				return mockSqlcUser, nil
+			},
+			CreateAccountFn: func(ctx context.Context, arg sqlc.CreateAccountParams) (sqlc.Account, error) {
+				return sqlc.Account{}, nil
 			},
 		}
 
@@ -399,14 +383,12 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 			RollbackFn: func(ctx context.Context) error { return errors.New("rollback error") },
 		}
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{}, pgx.ErrNoRows
-				},
-				CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
-					return sqlc.User{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{}, pgx.ErrNoRows
+			},
+			CreateUserFn: func(ctx context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
+				return sqlc.User{}, errors.New("db error")
 			},
 		}
 
@@ -442,14 +424,12 @@ func TestService_CreateOauthTokenForGithubUser(t *testing.T) {
 
 		defer restore()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
-					return sqlc.Account{UserID: mockUserID}, nil
-				},
-				GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
-					return mockSqlcUser, nil
-				},
+		db := &test.MockQuerier{
+			GetAccountByProviderFn: func(ctx context.Context, arg sqlc.GetAccountByProviderParams) (sqlc.Account, error) {
+				return sqlc.Account{UserID: mockUserID}, nil
+			},
+			GetUserByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.User, error) {
+				return mockSqlcUser, nil
 			},
 		}
 

--- a/internal/features/auth/service_jwt_test.go
+++ b/internal/features/auth/service_jwt_test.go
@@ -58,11 +58,9 @@ func TestService_ValidateOauthToken(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		userID := uuid.New()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
-					return mockUserWithAccount, nil
-				},
+		db := &test.MockQuerier{
+			GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
+				return mockUserWithAccount, nil
 			},
 		}
 
@@ -152,11 +150,9 @@ func TestService_ValidateOauthToken(t *testing.T) {
 	t.Run("GetUserWithAccountByID Error", func(t *testing.T) {
 		userID := uuid.New()
 
-		db := &auth.TestMockQuerier{
-			MockQuerier: test.MockQuerier{
-				GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
-					return sqlc.GetUserWithAccountByIDRow{}, errors.New("db error")
-				},
+		db := &test.MockQuerier{
+			GetUserWithAccountByIDFn: func(ctx context.Context, id pgtype.UUID) (sqlc.GetUserWithAccountByIDRow, error) {
+				return sqlc.GetUserWithAccountByIDRow{}, errors.New("db error")
 			},
 		}
 

--- a/internal/features/auth/service_test.go
+++ b/internal/features/auth/service_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/ccrsxx/api/internal/test"
 )
 
+func TestNewService_BindsRealQuerierToTx(t *testing.T) {
+	base := &sqlc.Queries{}
+
+	svc := auth.NewService(auth.ServiceConfig{Database: base})
+
+	bound := svc.NewTxQuerier(&test.MockTx{})
+
+	// A real *sqlc.Queries must be bound to the tx (a fresh instance), not
+	// reused as-is (which would run queries on the pool, outside the tx).
+	if bound == base {
+		t.Fatal("safety net did not bind to the tx: got the pool-bound base instance")
+	}
+}
+
 func TestService_getAuthorizationFromBearerToken(t *testing.T) {
 	ctx := context.Background()
 
@@ -221,14 +235,4 @@ func TestService_IsAdminFromOauth(t *testing.T) {
 			t.Errorf("got %v, want is admin user from context error", err)
 		}
 	})
-}
-
-func TestAuthDatabaseWrapper_WithTx(t *testing.T) {
-	wrapper := &auth.AuthDatabaseWrapper{Queries: &sqlc.Queries{}}
-
-	result := wrapper.WithTx(&test.MockTx{})
-
-	if result == nil {
-		t.Fatal("expected non-nil querier from WithTx")
-	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -105,7 +105,7 @@ func LoadHandlers(ctx context.Context, cfg config.AppConfig, pool *pgxpool.Pool,
 
 	authService := auth.ServiceConfig{
 		Pool:              pool,
-		Database:          &auth.AuthDatabaseWrapper{Queries: db},
+		Database:          db,
 		SecretKey:         cfg.SecretKey,
 		JwtSecret:         cfg.JWTSecret,
 		GithubClient:      githubClient,


### PR DESCRIPTION
More dry for adding transaction on a feature while supporting a test. And keeping each specific interface needs than big interface for each feature.